### PR TITLE
Restore ellipsis to match original page scan

### DIFF
--- a/src/epub/text/chapter-1.xhtml
+++ b/src/epub/text/chapter-1.xhtml
@@ -66,7 +66,7 @@
 			<p>“But <em>are</em> there any woods?” asked Kathleen as they passed the marketplace.</p>
 			<p>“It doesn’t much matter about woods,” said Gerald dreamily, “we’re sure to find <em>something</em>. One of the chaps told me his father said when he was a boy there used to be a little cave under the bank in a lane near the Salisbury Road; but he said there was an enchanted castle there too, so perhaps the cave isn’t true either.”</p>
 			<p>“If we were to get horns,” said Kathleen, “and to blow them very hard all the way, we might find a magic castle.”</p>
-			<p>“If you’ve got the money to throw away on horns⁠—” said Jimmy contemptuously.</p>
+			<p>“If you’ve got the money to throw away on horns…” said Jimmy contemptuously.</p>
 			<p>“Well, I have, as it happens, so there!” said Kathleen. And the horns were bought in a tiny shop with a bulging window full of a tangle of toys and sweets and cucumbers and sour apples.</p>
 			<p>And the quiet square at the end of the town where the church is, and the houses of the most respectable people, echoed to the sound of horns blown long and loud. But none of the houses turned into enchanted castles. Away they went along the Salisbury Road, which was very hot and dusty, so they agreed to drink one of the bottles of ginger-beer.</p>
 			<p>“We might as well carry the ginger-beer inside us as inside the bottle,” said Jimmy, “and we can hide the bottle and call for it as we come back.”</p>


### PR DESCRIPTION
The dash seemed strange here. I checked the original page scan, and it uses an ellipsis. The ellipsis was removed in commit 8f24afe9040c0bb372d11d7ce8be06b5a1d93582, but I'm not sure why. The text makes more sense with an ellipsis, as if Jimmy is trailing off, instead of a dash, which could imply he was interrupted.

I'm not sure if HORIZONTAL ELLIPSIS (U+2026) is preferred over `...` here. I can change it if needed.