### PR TITLE
Add missing word to improve grammar

### DIFF
--- a/src/epub/text/chapter-1.xhtml
+++ b/src/epub/text/chapter-1.xhtml
@@ -20,7 +20,7 @@
 			<p>“There aren’t any caves,” said Jimmy, who was fond of contradicting everyone. “And, besides, your precious Mamselle won’t let us go out alone, as likely as not.”</p>
 			<p>“Oh, we’ll see about that,” said Gerald. “I’ll go and talk to her like a father.”</p>
 			<p>“Like that?” Kathleen pointed the thumb of scorn at him, and he looked in the glass.</p>
-			<p>“To brush his hair and his clothes and to wash his face and hands was to our hero but the work of a moment,” said Gerald, and went to suit the action to the word.</p>
+			<p>“To brush his hair and his clothes and to wash his face and hands was to our hero but the work of a moment,” said Gerald, and he went to suit the action to the word.</p>
 			<p>It was a very sleek boy, brown and thin and interesting-looking, that knocked at the door of the parlour where Mademoiselle sat reading a yellow-covered book and wishing vain wishes. Gerald could always make himself look interesting at a moment’s notice, a very useful accomplishment in dealing with strange grownups. It was done by opening his grey eyes rather wide, allowing the corners of his mouth to droop, and assuming a gentle, pleading expression, resembling that of the late little Lord Fauntleroy⁠—who must, by the way, be quite old now, and an awful prig.</p>
 			<p>“<i xml:lang="fr">Entrez!</i>” said Mademoiselle, in shrill French accents. So he entered.</p>
 			<p>“<i xml:lang="fr">Eh bien?</i>” she said rather impatiently.</p>


### PR DESCRIPTION
This change is not in the original, but I think it improves the sentence, which caused me a moment of confusion. An alternative change would be:

```diff
- said Gerald, and went
+ said Gerald, who went
```

I'm not sure how much you want to stick to the original text. I won't be offended if this is considered too much of a diversion.